### PR TITLE
Rename fp-execute skill to fp-implement

### DIFF
--- a/fp/.claude-plugin/plugin.json
+++ b/fp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fp",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "description": "Local-first issue tracking and code review for humans and AI agents.",
   "author": {
     "name": "Fiberplane",

--- a/fp/README.md
+++ b/fp/README.md
@@ -54,7 +54,7 @@ fp review MYPROJ-a
 ### Skills
 
 - **fp-plan**: Create plans and break them down into trackable issues. Supports importing from GitHub, Linear, and Notion URLs.
-- **fp-execute**: Find, claim, and complete work on issues. Track progress with comments.
+- **fp-implement**: Find, claim, and complete work on issues. Track progress with comments.
 - **fp-review**: Ensure commits are assigned to issues, leave review comments, and use the web UI for interactive review.
 
 ## Data Storage

--- a/fp/skills/fp-implement/SKILL.md
+++ b/fp/skills/fp-implement/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: fp-execute
-description: Execute work on issues. Use when user asks to "start working on issue", "what should I work on", "pick up task", "continue work", or "find next task".
+name: fp-implement
+description: Implement work on issues. Use when user asks to "start working on issue", "what should I work on", "pick up task", "continue work", or "find next task".
 ---
 
-# FP Execute Skill
+# FP Implement Skill
 
 **Find, claim, and complete work on issues.**
 


### PR DESCRIPTION
## Summary
Renamed the `fp-execute` skill to `fp-implement` throughout the codebase to better reflect the purpose of the skill and improve naming clarity.

## Changes
- Renamed skill directory from `fp-execute` to `fp-implement`
- Updated skill name in `SKILL.md` metadata from `fp-execute` to `fp-implement`
- Updated skill description to use "Implement" instead of "Execute"
- Updated main README.md to reference `fp-implement` instead of `fp-execute`
- Updated skill heading from "FP Execute Skill" to "FP Implement Skill"

## Details
This change improves the semantic accuracy of the skill name. "Implement" better describes the action of finding, claiming, and completing work on issues compared to the more generic "execute" terminology.

https://claude.ai/code/session_01MNU13fxCSxrwRKJqcDuGD6