### PR TITLE
Update fp CLI checks and bump version to 0.12.1

### DIFF
--- a/fp/.claude-plugin/plugin.json
+++ b/fp/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fp",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Local-first issue tracking and code review for humans and AI agents.",
   "author": {
     "name": "Fiberplane",

--- a/fp/skills/fp-execute/SKILL.md
+++ b/fp/skills/fp-execute/SKILL.md
@@ -13,7 +13,7 @@ Before using fp commands, check setup:
 
 ```bash
 # Check if fp is installed
-which fp
+fp --version
 ```
 
 **If fp is not installed**, tell the user:
@@ -24,7 +24,7 @@ which fp
 
 ```bash
 # Check if project is initialized
-test -d .fp && echo "initialized" || echo "not initialized"
+fp tree
 ```
 
 **If project is not initialized**, ask the user if they want to initialize:

--- a/fp/skills/fp-plan/SKILL.md
+++ b/fp/skills/fp-plan/SKILL.md
@@ -13,7 +13,7 @@ Before using fp commands, check setup:
 
 ```bash
 # Check if fp is installed
-which fp
+fp --version
 ```
 
 **If fp is not installed**, tell the user:
@@ -24,7 +24,7 @@ which fp
 
 ```bash
 # Check if project is initialized
-test -d .fp && echo "initialized" || echo "not initialized"
+fp tree
 ```
 
 **If project is not initialized**, ask the user if they want to initialize:

--- a/fp/skills/fp-review/SKILL.md
+++ b/fp/skills/fp-review/SKILL.md
@@ -13,7 +13,7 @@ Before using fp commands, check setup:
 
 ```bash
 # Check if fp is installed
-which fp
+fp --version
 ```
 
 **If fp is not installed**, tell the user:
@@ -24,7 +24,7 @@ which fp
 
 ```bash
 # Check if project is initialized
-test -d .fp && echo "initialized" || echo "not initialized"
+fp tree
 ```
 
 **If project is not initialized**, ask the user if they want to initialize:


### PR DESCRIPTION
## Summary
This PR updates the fp CLI setup verification commands across all skill documentation and bumps the plugin version to 0.12.1.

## Key Changes
- **Version bump**: Updated plugin version from 0.12.0 to 0.12.1
- **CLI verification improvements**: Replaced generic shell checks with fp-native commands:
  - Changed `which fp` to `fp --version` for installation verification (more reliable and provides version info)
  - Changed `test -d .fp && echo "initialized" || echo "not initialized"` to `fp tree` for project initialization check (uses native fp command)
- **Documentation updates**: Applied these changes consistently across three skill files:
  - `fp/skills/fp-execute/SKILL.md`
  - `fp/skills/fp-plan/SKILL.md`
  - `fp/skills/fp-review/SKILL.md`

## Implementation Details
The new verification commands are more robust because they:
1. Use fp's native commands instead of relying on filesystem checks
2. Provide more meaningful output (version info, tree structure) rather than just success/failure
3. Are more portable and less dependent on shell-specific syntax

https://claude.ai/code/session_011xSUTrr8maVi5n5e4TiFV9